### PR TITLE
fix: fixed mistakes in README.md and changed exported rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Example:
 ```
 //examples:test_config_yml
 
-load("//prometheus:defs.bzl", "promtool_config_test")
+load("@io_bazel_rules_prometheus//prometheus:defs.bzl", "promtool_config_test")
 promtool_config_test(
     name = "test_config_yml",
     srcs = ["prometheus.yml"],
@@ -120,7 +120,7 @@ Example:
 ```
 //examples:unit_test_rules_yml
 
-load("//prometheus:defs.bzl", "promtool_unit_test")
+load("@io_bazel_rules_prometheus//prometheus:defs.bzl", "promtool_unit_test")
 promtool_unit_test(
 name = "unit_test_rules_yml",
 srcs = [
@@ -163,7 +163,7 @@ Tool will have access to workspace. It is intended for convenient in-workspace u
 
 Example:
 ```
-load("//prometheus:defs.bzl", "prometheus")
+load("@io_bazel_rules_prometheus//prometheus:defs.bzl", "prometheus")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -198,7 +198,7 @@ This rule will emit runnable sh_binary target which will invoke promtool binary 
 Example:
 ```
 //:promtool
-load("//prometheus:defs.bzl", "promtool")
+load("@io_bazel_rules_prometheus//prometheus:defs.bzl", "promtool")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/prometheus/defs.bzl
+++ b/prometheus/defs.bzl
@@ -12,7 +12,10 @@ load(
 load(
     "@io_bazel_rules_prometheus//prometheus/internal:prom.bzl",
     _prometheus = "prometheus",
+    _prometheus_server="prometheus_server",
 )
+
+
 load(
     "@io_bazel_rules_prometheus//prometheus/internal:toolchain.bzl",
     _prometheus_toolchains = "prometheus_toolchains",
@@ -25,3 +28,4 @@ promtool_config_test = _promtool_config_test
 promtool = _promtool
 promtool_rules_test = _promtool_rules_test
 prometheus = _prometheus
+prometheus_server = _prometheus_server 


### PR DESCRIPTION
There were few mistakes in README.md file related to import paths for "load" directives, and misunderstanding in using basic "prometheus" rule with a private template, so it's better to allow using "prometheus_server" as a manual option