### PR TITLE
fix empty glob patterns

### DIFF
--- a/prometheus/internal/BUILD
+++ b/prometheus/internal/BUILD
@@ -10,8 +10,6 @@ package(
 
 exports_files(
     glob([
-        "*.bat",
-        "*.sh",
         "*.sh.tpl",
     ]),
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Description:
These patterns are unnecessary and bazel will complain if [--incompatible_disallow_empty_glob](https://bazel.build/reference/command-line-reference#flag--incompatible_disallow_empty_glob) is set,
```
$ bazel query --incompatible_disallow_empty_glob //...
ERROR: Traceback (most recent call last):
        File "/home/jamison/code/rules_prometheus/prometheus/internal/BUILD", line 12, column 9, in <toplevel>
                glob([
Error in glob: glob pattern '*.bat' didn't match anything, but allow_empty is set to False (the default value of allow_empty can be set with --incompatible_disallow_empty_glob).
ERROR: package contains errors: prometheus/internal
ERROR: error loading package 'prometheus/internal': Package 'prometheus/internal' contains errors
Loading: 1 packages loaded

```

Tested by running:
`bazel query --incompatible_disallow_empty_glob //...`